### PR TITLE
Fixes in tests for go 1.14.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,6 +6,8 @@ environment:
   GOPATH: c:\gopath
   matrix:
     - go: 1.12.x
+    - go: 1.13.x
+    - go: 1.14.x
 
 platform:
   - x64

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: go
 
 go:
   - 1.12.x
+  - 1.13.x
+  - 1.14.x
 
 branches: # build only on these branches
   only:

--- a/credentials/credential_test.go
+++ b/credentials/credential_test.go
@@ -179,7 +179,7 @@ func Test_doaction(t *testing.T) {
 		Proxy: "# #%gfdf",
 	}
 	content, err = doAction(request, runtime)
-	assert.Equal(t, `parse # #%gfdf: invalid URL escape "%gf"`, err.Error())
+	assert.Equal(t, `parse "# #%gfdf": invalid URL escape "%gf"`, err.Error())
 	assert.NotNil(t, err)
 	assert.Nil(t, content)
 }

--- a/credentials/credential_test.go
+++ b/credentials/credential_test.go
@@ -179,7 +179,7 @@ func Test_doaction(t *testing.T) {
 		Proxy: "# #%gfdf",
 	}
 	content, err = doAction(request, runtime)
-	assert.Equal(t, `parse "# #%gfdf": invalid URL escape "%gf"`, err.Error())
+	assert.Contains(t, err.Error(), `invalid URL escape`)
 	assert.NotNil(t, err)
 	assert.Nil(t, content)
 }

--- a/credentials/profile_provider_test.go
+++ b/credentials/profile_provider_test.go
@@ -295,13 +295,13 @@ func TestProfileProvider(t *testing.T) {
 	p = newProfileProvider("NonExist")
 	c, err = p.resolve()
 	assert.Nil(t, c)
-	assert.Equal(t, "ERROR: Can not load section section \"NonExist\" does not exist", err.Error())
+	assert.Equal(t, "ERROR: Can not load section section 'NonExist' does not exist", err.Error())
 
 	// testcase 6, credential type does not set
 	p = newProfileProvider("notype")
 	c, err = p.resolve()
 	assert.Nil(t, c)
-	assert.Equal(t, "Missing required type option error when getting key of section \"notype\": key \"type\" not exists", err.Error())
+	assert.Equal(t, "Missing required type option error when getting key of section 'notype': key 'type' not exists", err.Error())
 
 	// testcase 7, normal AK
 	p = newProfileProvider()

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/aliyun/credentials-go
 
+go 1.14
+
 require (
 	github.com/alibabacloud-go/debug v0.0.0-20190504072949-9472017b5c68
 	github.com/alibabacloud-go/tea v1.1.0


### PR DESCRIPTION
We are trying to package credentials-go as an RPM package for Fedora 33 and later.  Fedora 33 builds with go 1.14.  We found that three tests failed due to string format changes between versions of go.  This patch fixes these errors that we found downstream.