### PR TITLE
Fix SetOIDCTokenFilePath method doesn't update the value of OIDCTokenFilePath field

### DIFF
--- a/credentials/credential.go
+++ b/credentials/credential.go
@@ -151,7 +151,7 @@ func (s *Config) SetType(v string) *Config {
 }
 
 func (s *Config) SetOIDCTokenFilePath(v string) *Config {
-	s.Type = &v
+	s.OIDCTokenFilePath = &v
 	return s
 }
 

--- a/credentials/credential_test.go
+++ b/credentials/credential_test.go
@@ -174,6 +174,17 @@ func Test_NewCredential(t *testing.T) {
 	cred, err = NewCredential(config)
 	assert.Nil(t, err)
 	assert.NotNil(t, cred)
+
+	config.SetType("oidc_role_arn").
+		SetOIDCProviderArn("oidc_provider_arn_test").
+		SetOIDCTokenFilePath("oidc_token_file_path_test").
+		SetRoleArn("role_arn_test")
+	cred, err = NewCredential(config)
+	assert.Nil(t, err)
+	assert.NotNil(t, cred)
+	assert.Equal(t, "oidc_provider_arn_test", tea.StringValue(config.OIDCProviderArn))
+	assert.Equal(t, "oidc_token_file_path_test", tea.StringValue(config.OIDCTokenFilePath))
+	assert.Equal(t, "role_arn_test", tea.StringValue(config.RoleArn))
 }
 
 func Test_doaction(t *testing.T) {


### PR DESCRIPTION


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/aliyun/credentials-go/blob/master/CONTRIBUTING.md
-->

##### You need to complete
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] unit tests and/or feature tests